### PR TITLE
LIBITD-2532. Created API's groups view with placeholder data

### DIFF
--- a/src/ipmanager/api/views.py
+++ b/src/ipmanager/api/views.py
@@ -1,1 +1,24 @@
 # Create your views here.
+from django.views import View
+from django.http import JsonResponse
+
+class GroupsView(View):
+    def get(self, request):
+        # Grab full request URL
+        request_url = request.build_absolute_uri()
+        exported_groups = ["Group1Key", "Group2Key", "Group3Key"]
+        groups = []
+
+        # Populate the groups array, where each group is a dict
+        for group_key in exported_groups:
+            groups.append({
+                "@id": request_url + group_key,
+                "key": group_key,
+                "name": group_key + "'s name"
+            })
+
+        body = {
+            "@id": request_url,
+            "groups": groups,
+        }
+        return JsonResponse(body)

--- a/src/ipmanager/urls.py
+++ b/src/ipmanager/urls.py
@@ -18,6 +18,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from ipmanager.api.views import GroupsView
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('groups/', GroupsView.as_view())
 ]


### PR DESCRIPTION
We started creating the views first for the IPManager API, instead of the models. I put in some placeholder data for the view. This view represents the "/groups" route.

https://umd-dit.atlassian.net/browse/LIBITD-2532