### PR TITLE
LIBITD-2637 Multiple notes on Group detail view.

### DIFF
--- a/src/ipmanager/ui/templates/ui/single_group_view.html
+++ b/src/ipmanager/ui/templates/ui/single_group_view.html
@@ -68,6 +68,24 @@
     >Edit Group</a
   >
 
+  <!--
+  Add the <h2> heading right here for the Notes
+  -->
+  <h2>Notes</h2>
+
+  <table class="lined expanded">
+    <tbody>
+      {% for note in notes %}
+      <tr>
+        <td>{{ note.created|date:"F j, Y"}} {{ note.created|time:"g:i:sA" }}</td>
+        <td>{{note.user}}</td>
+        <td>{{note.content}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+
   <h2>IP Ranges</h2>
 
   <table class="lined expanded">

--- a/src/ipmanager/ui/views.py
+++ b/src/ipmanager/ui/views.py
@@ -6,7 +6,7 @@ from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from ipmanager.api.models import Group, IPRange, Relation
+from ipmanager.api.models import Group, IPRange, Relation, Note
 from ipmanager.ui.forms import IPRangeForm, RelationForm, TestIPForm
 
 class RootView(TemplateView):
@@ -73,6 +73,7 @@ class SingleGroupView(LoginRequiredMixin, DetailView):
                 subject=current_group, relation=Relation.RelationType.EXCLUSION
             ),
             ip_range_form=IPRangeForm(initial={'group': current_group}),
+            notes=Note.objects.filter(group=current_group),
             form=TestIPForm,
             contained=contained,
             test_ip=test_ip,


### PR DESCRIPTION
Updated the single_group detail view to display multiple notes. Each note includes a human-friendly datetime, the username of the user who created it, and the text content of the note.

https://umd-dit.atlassian.net/browse/LIBITD-2637