### PR TITLE
LIBITD-2656. Updates to Dockerfile, settings.py, and compose.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,25 @@
-FROM python:3.13-slim
+FROM python:3.12.12-slim
 
-# Install git
 RUN apt-get update && \
-    apt-get install -y git xmlsec1 && \
+    apt-get install -y xmlsec1 && \
     apt-get clean
+# ensure we have pip 25.1+ for PEP 735 dependency groups
+RUN pip install --upgrade pip
 
-# Set environment variables
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Set work directory
 WORKDIR /opt/ipmanager
 
-# Install dependencies
 COPY pyproject.toml .
-
-# Copy project
 COPY src ./src
 COPY attribute-maps ./attribute-maps
-RUN pip install -e .[prod]
+
+RUN pip install -e . --group prod
+
 RUN src/manage.py collectstatic
 
-# PORT
 EXPOSE 3001
 
 # Commands to run migration and start the server
-CMD sh -c "src/manage.py migrate && ipmanager"
+CMD ["sh", "-c", "src/manage.py migrate && ipmanager"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,56 +1,44 @@
-version: "1"
-
 services:
-  ipmanager-postgres:
+  db:
     image: postgres:17
-    networks: 
-      - ipmanager-network
     volumes:
-      - ./dockervols/postgres-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     ports:
       - "5432"
     environment:
-      - "POSTGRES_PASSWORD=Pass1234"
-      - "POSTGRES_USER=ipmanager"
-      - "POSTGRES_DB=ipmanager"
+      - POSTGRES_PASSWORD=Pass1234
+      - POSTGRES_USER=ipmanager
+      - POSTGRES_DB=ipmanager
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "ipmanager"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
 
-  start-ipmanager-dependencies:
-    image: dadarek/wait-for-dependencies
-    networks:
-      - ipmanager-network
-    depends_on:
-     - "ipmanager-postgres"
-    command: "ipmanager-postgres:5432"
-
-  ipmanager-web:
+  app:
+    image: docker.lib.umd.edu/ipmanager-django:latest
     build:
       context: .
       dockerfile: Dockerfile
-    networks:
-      - ipmanager-network
     ports:
       - "3001:3001"
     volumes:
       - ./env:/etc/ipmanager/saml
     environment:
-      - "BASE_URL=http://ipmanager-local:3001/"
-      - "DB_ENGINE=django.db.backends.postgresql"
-      - "DB_HOST=ipmanager-postgres"
-      - "DB_PORT=5432"
-      - "DB_NAME=ipmanager"
-      - "DB_USER=ipmanager"
-      - "DB_PASSWORD=Pass1234"
-      - "SERVER_PORT=3001"
-      - "XMLSEC1_PATH=/usr/bin/xmlsec1"
-      - "SECRET_KEY=9cc159ea50782f9cd254793eb1ad604d381549a6f9ae7dcaef8d6cbed17406c0"
-      - "ENVIRONMENT=production"
-      - "DEBUG=true"
-      - "SAML_KEY_FILE=/etc/ipmanager/saml/ipmanager-key.key"
-      - "SAML_CERT_FILE=/etc/ipmanager/saml/ipmanager-cert.crt"
-      - "SESSION_COOKIE_SECURE=False"
-      - "SAML_SESSION_COOKIE_SAMESITE=Lax"
+      - DB_ENGINE=django.db.backends.postgresql
+      - DB_HOST=db
+      - DB_NAME=ipmanager
+      - DB_PASSWORD=Pass1234
+      - DB_PORT=5432
+      - DB_USER=ipmanager
+      - SAML_CERT_FILE=/etc/ipmanager/saml/ipmanager-local.crt
+      - SAML_KEY_FILE=/etc/ipmanager/saml/ipmanager-local.key
+      - SAML_SESSION_COOKIE_SAMESITE=Lax
+      - SECRET_KEY=9cc159ea50782f9cd254793eb1ad604d381549a6f9ae7dcaef8d6cbed17406c0
+      - SESSION_COOKIE_SECURE=False
     depends_on:
-     - "start-ipmanager-dependencies"
-    
-networks:
-  ipmanager-network:
+      db:
+        condition: service_healthy
+
+volumes:
+  db-data:

--- a/src/ipmanager/settings.py
+++ b/src/ipmanager/settings.py
@@ -30,7 +30,7 @@ STATIC_ROOT = str(BASE_DIR / 'staticfiles')
 Env.read_env(BASE_DIR / '.env')
 env = Env()
 
-BASE_URL = URLObject(env.str('BASE_URL', 'http://localhost:5000'))
+BASE_URL = URLObject(env.str('BASE_URL', 'http://ipmanager-local:3001'))
 CSRF_TRUSTED_ORIGINS = [str(BASE_URL.with_path(''))]
 
 # Quick-start development settings - unsuitable for production
@@ -43,7 +43,7 @@ SECRET_KEY = env('SECRET_KEY', default=get_random_secret_key())
 DEBUG = env.bool('DEBUG', False)
 
 SERVER_HOST = env.str('SERVER_HOST', '0.0.0.0')
-SERVER_PORT = env.str('SERVER_PORT', '3001')
+SERVER_PORT = env.int('SERVER_PORT', 3001)
 runserver.default_addr = SERVER_HOST
 runserver.default_port = SERVER_PORT
 


### PR DESCRIPTION
Dockerfile:

- use Python 3.12.12 base image, to align with `.python-version` of 3.12
- remove git from the `apt-get install` (it was not used)
- ensure the latest pip to use PEP 735 dependency groups when installing
- convert the `CMD` to use JSON syntax

settings.py:

- changed `SERVER_PORT` to int
- changed `BASE_URL` to "ipmanager-local:3001"

compose.yaml:

- use Docker-managed volume for database
- renamed containers to "db" and "app"
- removed custom network
- removed unnecessary quotes from environment variables
- removed start-ipmanagers-dependencies container; using a healthcheck instead

https://umd-dit.atlassian.net/browse/LIBITD-2656