### PR TITLE
LIBITD-2663. Change default dimensions of notes text box.

### DIFF
--- a/src/ipmanager/ui/forms.py
+++ b/src/ipmanager/ui/forms.py
@@ -1,4 +1,4 @@
-from django.forms import CharField, Form, HiddenInput, ModelForm
+from django.forms import CharField, Form, HiddenInput, ModelForm, Textarea
 
 from ipmanager.api.models import IPRange, Relation, Note
 
@@ -18,6 +18,7 @@ class NoteForm(ModelForm):
         widgets = {
             'user': HiddenInput(),
             'group': HiddenInput(),
+            'content': Textarea(attrs={'cols': 60, 'rows': 2})
         }
 
 

--- a/src/ipmanager/ui/templates/ui/single_group_view.html
+++ b/src/ipmanager/ui/templates/ui/single_group_view.html
@@ -99,13 +99,16 @@
   </table>
 
   {% if is_superuser %}
-  <form method="post" action="{% url 'create_note' group.key %}">
-    {% csrf_token %}
-    <div class="horizontal-container">
-      {{ note_form }}
-      <button type="submit" class="create">Add Note</button>
-    </div>
-  </form>
+    <form 
+      method="post" 
+      action="{% url 'create_note' group.key %}"
+      >
+      {% csrf_token %}
+      <div class="horizontal-container">
+        {{ note_form }}
+        <button type="submit" class="create">Add Note</button>
+      </div>
+    </form>
   {% endif %}
 
   <h2>IP Ranges</h2>


### PR DESCRIPTION
Changed the default width and heights of the notes text box on the grouppage to 60 columns wide by 2 lines high.

https://umd-dit.atlassian.net/browse/LIBITD-2663