### PR TITLE
LIBITD-2668. Make the `ALLOWED_HOSTS` configurable.

### DIFF
--- a/src/ipmanager/settings.py
+++ b/src/ipmanager/settings.py
@@ -49,7 +49,7 @@ runserver.default_port = SERVER_PORT
 
 DOMAIN_NAME = env.str('DOMAIN_NAME', 'ipmanager-local')
 
-ALLOWED_HOSTS = [BASE_URL.hostname, '0.0.0.0']
+ALLOWED_HOSTS = [BASE_URL.hostname, *env.list('OTHER_ALLOWED_HOSTS', default=[])]
 
 # Add the IP address (used by k8s health probes)
 try:


### PR DESCRIPTION
- initial `ALLOWED_HOSTS` setting is the hostname of the `BASE_URL`
- read an optional `OTHER_ALLOWED_HOSTS` environment variable and add those names (if any) to the `ALLOWED_HOSTS` list

https://umd-dit.atlassian.net/browse/LIBITD-2668